### PR TITLE
Fix permited/permuted dims typo in candecomp.jl

### DIFF
--- a/src/candecomp.jl
+++ b/src/candecomp.jl
@@ -121,7 +121,7 @@ function _candecomp(
             mul!(gram[i], factors[i]', factors[i])
         end
         resid_old = resid
-        resid = norm(view(V, 1:nVi, :) * permitedims((factors[N] .* lbds)) .- tnsr_flat)
+        resid = norm(view(V, 1:nVi, :) * permutedims((factors[N] .* lbds)) .- tnsr_flat)
         converged = abs(resid - resid_old) < tol * resid_old
         niters += 1
     end


### PR DESCRIPTION
The package works fine with one small change to fix a typo on permutedims